### PR TITLE
Typo in CSS example.  Changed ul -> ol.

### DIFF
--- a/exercises/css/ex_16.md
+++ b/exercises/css/ex_16.md
@@ -56,7 +56,7 @@
   * Add 20px to margin top only
 * Select all li elements and apply the following style:
   * The list item style position must be inside
-* Select only the ul list and apply the following style:
+* Select only the ol list and apply the following style:
   * List style must be decimal-leading-zero
 * Select only the ul list and apply the following style:
   * List style must be square


### PR DESCRIPTION
My comment goes in here.